### PR TITLE
Improved the PKGBUILD + replacing the grub PKGBUILD

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,26 +1,25 @@
 # Maintainer:  echo -n 'TWF0dCBDLiA8bWF0dEBnZXRjcnlzdC5hbD4='     | base64 -d
 # Contributor: echo -n 'TWljaGFsIFMuIDxtaWNoYWxAZ2V0Y3J5c3QuYWw+' | base64 -d
+# Contributor: echo -n 'Um9iaW4gQy4gPHJjYW5kYXVAZ2V0Y3J5c3QuYWw+' | base64 -d
 
-_name=grub-theme
 
-pkgname="crystal-$_name"
+pkgname=crystal-grub-theme
+_pkgname=grub-theme
 pkgver=1.0.1
-pkgrel=1
+pkgrel=2
 pkgdesc='GRUB Theme for Crystal Linux'
 arch=('any')
+url="https://github.com/crystal-linux/${_pkgname}"
 license=('MIT')
-url="https://github.com/crystal-linux/$_name"
 depends=('grub')
-makedepends=('git')
-source=("git+$url")
-sha256sums=('SKIP')
+install="${pkgname}.install"
+source=("${pkgname}-${pkgver}::${url}/archive/v${pkgver}.tar.gz")
+sha256sums=('09d892520164598b5a866c7c82c9c1b55dfd7563a331e2bb01191a0d88d4683c')
 
 package() {
-    cd "$srcdir/$_name"
-        
-    mkdir -p \
-        "$pkgdir/usr/share/grub/themes"
-                
-    cp -R crystal \
-        "$pkgdir/usr/share/grub/themes/."
+    cd "${srcdir}/${_pkgname}-${pkgver}"        
+    install -d "${pkgdir}/usr/share/grub/themes"
+    cp -R crystal "${pkgdir}/usr/share/grub/themes/"
+    install -Dm 644 "LICENSE" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+    install -Dm 644 "README.md" "${pkgdir}/usr/share/doc/${pkgname}/README.md"
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -12,7 +12,6 @@ arch=('any')
 url="https://github.com/crystal-linux/${_pkgname}"
 license=('MIT')
 depends=('grub')
-install="${pkgname}.install"
 source=("${pkgname}-${pkgver}::${url}/archive/v${pkgver}.tar.gz")
 sha256sums=('09d892520164598b5a866c7c82c9c1b55dfd7563a331e2bb01191a0d88d4683c')
 

--- a/crystal-grub-theme.install
+++ b/crystal-grub-theme.install
@@ -1,0 +1,9 @@
+post_install() {
+	sed -i s/GRUB_DISTRIBUTOR=\"Arch\"/GRUB_DISTRIBUTOR=\"Crystal\"/g etc/default/grub
+	grub-mkconfig -o /boot/grub/grub.cfg
+}
+
+post_upgrade() {
+	sed -i s/GRUB_DISTRIBUTOR=\"Arch\"/GRUB_DISTRIBUTOR=\"Crystal\"/g etc/default/grub
+	grub-mkconfig -o /boot/grub/grub.cfg
+}

--- a/crystal-grub-theme.install
+++ b/crystal-grub-theme.install
@@ -1,9 +1,0 @@
-post_install() {
-	sed -i s/GRUB_DISTRIBUTOR=\"Arch\"/GRUB_DISTRIBUTOR=\"Crystal\"/g etc/default/grub
-	grub-mkconfig -o /boot/grub/grub.cfg
-}
-
-post_upgrade() {
-	sed -i s/GRUB_DISTRIBUTOR=\"Arch\"/GRUB_DISTRIBUTOR=\"Crystal\"/g etc/default/grub
-	grub-mkconfig -o /boot/grub/grub.cfg
-}


### PR DESCRIPTION
Hi team,

A round of improvements for the `grub-theme` PKGBUILD + dropping the [grub PKGBUILD](https://github.com/crystal-linux-packages/grub/):

- A bit of reformatting on the variable declaration to fit the standards.
- Switched all vars to the `${var}` format.
- Switched source from `git` to release's archive. Added the integrity check accordingly.
- Switched the `mkdir` command to an `install` command.
- Added the README file to the doc since it provide some documentations.
- Added the LICENSE file to the licenses folder (since `grub-theme` is licensed under the MIT license, it has to be provided).
- Added a post_install/upgrade script that does the change in `/etc/default/grub` which was previously handled by the [grub PKGBUILD](https://github.com/crystal-linux-packages/grub/). The later could (should) thus be dropped. See the below point for more information.

**About the last point:**
*Long story short*: As discussed on Discord, I think we shouldn't re-packaging already existing package. We should let Arch handle those to avoid additional (and potentially dangerous) maintenance on our side, it basically joins what I already stated for the `base` and `filesystem` package.
To be honest, I think the only two reasons we should create a package/PKGBUILD is either because it is our package (`ame`, `malachite`, `jade`, etc...) or because we want to add something on top of an already existing package (but not completely repackaging it our-self), *unless we fork it and it basically becomes our I guess*.
So the aim here is to use the post_install/upgrade script of this package to ship the crystal specific change to `/etc/default/grub` instead of repackaging the whole `grub` package our-self to do so.

What do you think?